### PR TITLE
feat: added setup with attributify mode using windicss

### DIFF
--- a/src/logic/compiler/windi.ts
+++ b/src/logic/compiler/windi.ts
@@ -7,12 +7,16 @@ export function generateStyles(html: string) {
     'dark:text-light-300',
     'text-dark-100',
   ].join(' ')
+
+  // Parse html to get array of class matches with location
+  const parser = new HTMLParser(html)
+
   const processor = new Processor({
     darkMode: 'class',
   })
 
   // Parse all classes and put into one line to simplify operations
-  const htmlClasses = new HTMLParser(html)
+  const htmlClasses = parser
     .parseClasses()
     .map(i => i.result)
     .join(' ')
@@ -23,10 +27,46 @@ export function generateStyles(html: string) {
   // Process the html classes to an interpreted style sheet
   const interpretedSheet = processor.interpret(`${htmlClasses} ${whitelist}`).styleSheet
 
+  // Always returns array
+  const castArray = (val: any) => (Array.isArray(val) ? val : [val])
+
+  const attrs: { [key: string]: string | string[] } = parser
+    .parseAttrs()
+    .reduceRight((acc: { [key: string]: string | string[] }, curr) => {
+      // get current match key
+      const attrKey = curr.key
+
+      // ignore class or className attributes
+      if (attrKey === 'class' || attrKey === 'className') return acc
+
+      // get current match value as array
+      const attrValue = castArray(curr.value)
+
+      // if current match key is already in accumulator
+      if (attrKey in acc) {
+        // get current attr key value as array
+        const attrKeyValue = castArray(acc[attrKey])
+
+        // append current value to accumulator value
+        acc[attrKey] = [...attrKeyValue, ...attrValue]
+      }
+      else {
+        // else add atrribute value array to accumulator
+        acc[attrKey] = attrValue
+      }
+
+      return acc
+    }, {})
+
+  const attrsSheet = processor.attributify(attrs)
+
   // Build styles
   const APPEND = false
   const MINIFY = false
-  const styles = interpretedSheet.extend(preflightSheet, APPEND).build(MINIFY)
+  const styles = attrsSheet.styleSheet
+    .extend(interpretedSheet)
+    .extend(preflightSheet, APPEND)
+    .build(MINIFY)
 
   // console.log('Styles', styles)
 


### PR DESCRIPTION
Added setup with `attributify` mode using `windicss`

The SFC Template could write like this:

```html
<div
  grid="~ flow-col gap-4"
  place="content-center items-center"
  class="h-screen font-mono">
  <div class="dark:bg-dark-500 bg-light-500 flex flex-col text-center p-2 rounded">
    <span class="text-4xl">{{ x }}</span>
    <span class="text-sm dark:text-light-900  dark:text-opacity-50 mt-2">Mouse X</span>
  </div>
  <div class="dark:bg-dark-500 bg-light-500 flex flex-col text-center p-2 rounded">
    <span class="text-4xl">{{ y }}</span>
    <span class="text-sm dark:text-light-900 dark:text-opacity-50 mt-2">Mouse Y</span>
  </div>
</div>
```