### PR TITLE
fix: avoid not capturing the event mouseup when dragging

### DIFF
--- a/src/components/playground/Preview.vue
+++ b/src/components/playground/Preview.vue
@@ -200,4 +200,8 @@ iframe {
   height: 100%;
   border: none;
 }
+
+.splitpanes--dragging iframe {
+  pointer-events: none;
+}
 </style>


### PR DESCRIPTION
fix: #30 

Solution：https://github.com/antoniandre/splitpanes/issues/88

After:

https://github.com/user-attachments/assets/87e95ebb-900f-41bb-bc9c-d37fed3c4be9